### PR TITLE
Final edits

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -122,6 +122,7 @@ func main() {
 		protected.PUT("/events/:id", eventHandler.UpdateDraftEvent)
 		protected.POST("/events/:id/publish", eventHandler.PublishEvent)
 		protected.POST("/events/:id/tickets", eventHandler.BuyTicket)
+		protected.POST("/events/:id/check-in", eventHandler.CheckInTicket)
 	}
 
 	srv := &http.Server{

--- a/api/internal/handler/event_handler.go
+++ b/api/internal/handler/event_handler.go
@@ -513,6 +513,63 @@ func (h *EventHandler) ListMyTickets(c *gin.Context) {
 	c.JSON(http.StatusOK, tickets)
 }
 
+// CheckInTicket marks one ticket as checked-in for an event owned by the signed-in organizer.
+func (h *EventHandler) CheckInTicket(c *gin.Context) {
+	uid, ok := authUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing auth"})
+		return
+	}
+
+	eventID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid event ID"})
+		return
+	}
+
+	var req models.CheckInTicketRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body: " + err.Error()})
+		return
+	}
+	req.CheckInMethod = strings.TrimSpace(req.CheckInMethod)
+	if req.CheckInMethod == "" {
+		req.CheckInMethod = "qr_scan"
+	}
+	if req.CheckInMethod != "qr_scan" && req.CheckInMethod != "manual" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "check_in_method must be either 'qr_scan' or 'manual'"})
+		return
+	}
+	if strings.TrimSpace(req.QRCodeValue) == "" && strings.TrimSpace(req.TicketNumber) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Provide either qr_code_value or ticket_number"})
+		return
+	}
+
+	ticket, checkedInAt, alreadyUsed, err := h.eventRepo.CheckInTicketForOrganizer(
+		c.Request.Context(),
+		eventID,
+		uid,
+		req.QRCodeValue,
+		req.TicketNumber,
+		req.CheckInMethod,
+		req.Notes,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Ticket not found for this organizer event"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check in ticket: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, models.CheckInTicketResponse{
+		Ticket:      *ticket,
+		CheckedInAt: checkedInAt,
+		AlreadyUsed: alreadyUsed,
+	})
+}
+
 // ListEcoAttributes godoc
 // @Summary      List eco attributes
 // @Description  Returns all eco attributes (use IDs when creating events)

--- a/api/internal/handler/event_handler_test.go
+++ b/api/internal/handler/event_handler_test.go
@@ -23,6 +23,7 @@ type fakeEventRepo struct {
 	listSavedFn   func(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.Event, error)
 	buyFn         func(ctx context.Context, eventID, userID uuid.UUID, ticketType string, quantity int) ([]models.Ticket, int, error)
 	listTicketsFn func(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.Ticket, error)
+	checkInFn     func(ctx context.Context, eventID, organizerID uuid.UUID, qrCodeValue, ticketNumber, method, notes string) (*models.Ticket, time.Time, bool, error)
 }
 
 func (f *fakeEventRepo) Create(ctx context.Context, req *models.CreateEventRequest, isEcoFriendly bool) (*models.Event, error) {
@@ -94,6 +95,17 @@ func (f *fakeEventRepo) ListTicketsByUser(ctx context.Context, userID uuid.UUID,
 		return f.listTicketsFn(ctx, userID, limit, offset)
 	}
 	return []models.Ticket{}, nil
+}
+
+func (f *fakeEventRepo) CheckInTicketForOrganizer(
+	ctx context.Context,
+	eventID, organizerID uuid.UUID,
+	qrCodeValue, ticketNumber, method, notes string,
+) (*models.Ticket, time.Time, bool, error) {
+	if f.checkInFn != nil {
+		return f.checkInFn(ctx, eventID, organizerID, qrCodeValue, ticketNumber, method, notes)
+	}
+	return nil, time.Time{}, false, pgx.ErrNoRows
 }
 
 type fakeVenueRepo struct {
@@ -321,6 +333,55 @@ func TestListMyTickets_OK(t *testing.T) {
 	c.Request = httptest.NewRequest(http.MethodGet, "/me/tickets", nil)
 
 	h.ListMyTickets(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCheckInTicket_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	eventID := uuid.New()
+	organizerID := uuid.New()
+	ticketID := uuid.New()
+	now := time.Now().UTC()
+
+	repo := &fakeEventRepo{
+		checkInFn: func(
+			ctx context.Context,
+			eid, oid uuid.UUID,
+			qrCodeValue, ticketNumber, method, notes string,
+		) (*models.Ticket, time.Time, bool, error) {
+			if eid != eventID || oid != organizerID {
+				t.Fatalf("unexpected ids eid=%s oid=%s", eid, oid)
+			}
+			if qrCodeValue == "" {
+				t.Fatalf("expected qr_code_value")
+			}
+			return &models.Ticket{
+				ID:           ticketID,
+				UserID:       uuid.New(),
+				EventID:      eventID,
+				TicketNumber: "EL-123",
+				TicketType:   "general",
+				Status:       "used",
+				QRCodeValue:  "eventleaf:ticket:" + ticketID.String(),
+			}, now, false, nil
+		},
+	}
+
+	h := NewEventHandler(repo, &fakeVenueRepo{}, &fakeEcoRepo{}, nil, "America/New_York")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextUserIDKey, organizerID.String())
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/events/"+eventID.String()+"/check-in",
+		bytes.NewBufferString(`{"qr_code_value":"eventleaf:ticket:abc","check_in_method":"qr_scan"}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: eventID.String()}}
+
+	h.CheckInTicket(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code %d body %s", w.Code, w.Body.String())
 	}

--- a/api/internal/handler/interfaces.go
+++ b/api/internal/handler/interfaces.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"time"
 
 	"github.com/Atul71/EventLeaf/api/internal/models"
 	"github.com/google/uuid"
@@ -32,6 +33,11 @@ type EventRepository interface {
 	GetEcoAttributeNamesByEventID(ctx context.Context, eventID uuid.UUID) ([]string, error)
 	BuyTicket(ctx context.Context, eventID, userID uuid.UUID, ticketType string, quantity int) ([]models.Ticket, int, error)
 	ListTicketsByUser(ctx context.Context, userID uuid.UUID, limit, offset int) ([]models.Ticket, error)
+	CheckInTicketForOrganizer(
+		ctx context.Context,
+		eventID, organizerID uuid.UUID,
+		qrCodeValue, ticketNumber, method, notes string,
+	) (*models.Ticket, time.Time, bool, error)
 }
 
 // VenueRepository is the subset of venue persistence used by HTTP handlers.

--- a/api/internal/models/ticket.go
+++ b/api/internal/models/ticket.go
@@ -17,6 +17,21 @@ type BuyTicketResponse struct {
 	RemainingTickets int      `json:"remaining_tickets"`
 }
 
+type CheckInTicketRequest struct {
+	// Either qr_code_value (preferred) or ticket_number can be provided.
+	QRCodeValue  string `json:"qr_code_value"`
+	TicketNumber string `json:"ticket_number"`
+	// Optional: "qr_scan" (default) or "manual".
+	CheckInMethod string `json:"check_in_method"`
+	Notes         string `json:"notes"`
+}
+
+type CheckInTicketResponse struct {
+	Ticket      Ticket    `json:"ticket"`
+	CheckedInAt time.Time `json:"checked_in_at"`
+	AlreadyUsed bool      `json:"already_used"`
+}
+
 type Ticket struct {
 	ID           uuid.UUID `json:"id"`
 	UserID       uuid.UUID `json:"user_id"`

--- a/api/internal/repository/event_repository.go
+++ b/api/internal/repository/event_repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/Atul71/EventLeaf/api/internal/db"
 	"github.com/Atul71/EventLeaf/api/internal/models"
@@ -573,6 +575,90 @@ func (r *EventRepository) ListTicketsByUser(ctx context.Context, userID uuid.UUI
 		out = append(out, t)
 	}
 	return out, rows.Err()
+}
+
+func (r *EventRepository) CheckInTicketForOrganizer(
+	ctx context.Context,
+	eventID, organizerID uuid.UUID,
+	qrCodeValue, ticketNumber, method, notes string,
+) (*models.Ticket, time.Time, bool, error) {
+	trimmedQR := strings.TrimSpace(qrCodeValue)
+	trimmedTicket := strings.TrimSpace(ticketNumber)
+	if trimmedQR == "" && trimmedTicket == "" {
+		return nil, time.Time{}, false, pgx.ErrNoRows
+	}
+
+	if method == "" {
+		method = "qr_scan"
+	}
+
+	tx, err := r.db.Pool.Begin(ctx)
+	if err != nil {
+		return nil, time.Time{}, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	var ticket models.Ticket
+	var existingCheckInID sql.NullString
+	var existingCheckedInAt sql.NullTime
+
+	err = tx.QueryRow(ctx, `
+		SELECT
+			t.id, t.user_id, t.event_id, t.ticket_number, t.ticket_type, t.status, t.price_paid,
+			t.purchase_date, t.created_at, t.updated_at,
+			ci.id, ci.checked_in_at
+		FROM tickets t
+		INNER JOIN events e ON e.id = t.event_id
+		LEFT JOIN check_ins ci ON ci.ticket_id = t.id AND ci.event_id = e.id
+		WHERE e.id = $1
+		  AND e.organizer_id = $2
+		  AND (
+			($3 <> '' AND ('eventleaf:ticket:' || t.id::text) = $3)
+			OR ($4 <> '' AND t.ticket_number = $4)
+		  )
+		ORDER BY ci.checked_in_at DESC NULLS LAST
+		LIMIT 1
+	`, eventID, organizerID, trimmedQR, trimmedTicket).Scan(
+		&ticket.ID, &ticket.UserID, &ticket.EventID, &ticket.TicketNumber, &ticket.TicketType, &ticket.Status, &ticket.PricePaid,
+		&ticket.PurchaseDate, &ticket.CreatedAt, &ticket.UpdatedAt,
+		&existingCheckInID, &existingCheckedInAt,
+	)
+	if err != nil {
+		return nil, time.Time{}, false, err
+	}
+	ticket.QRCodeValue = fmt.Sprintf("eventleaf:ticket:%s", ticket.ID.String())
+
+	if existingCheckInID.Valid && existingCheckedInAt.Valid {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, time.Time{}, false, err
+		}
+		return &ticket, existingCheckedInAt.Time, true, nil
+	}
+
+	var checkedInAt time.Time
+	err = tx.QueryRow(ctx, `
+		INSERT INTO check_ins (ticket_id, event_id, check_in_method, checked_in_by, notes)
+		VALUES ($1, $2, $3, $4, NULLIF($5, ''))
+		RETURNING checked_in_at
+	`, ticket.ID, eventID, method, organizerID, strings.TrimSpace(notes)).Scan(&checkedInAt)
+	if err != nil {
+		return nil, time.Time{}, false, err
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE tickets
+		SET status = 'used', updated_at = NOW()
+		WHERE id = $1 AND status = 'active'
+	`, ticket.ID)
+	if err != nil {
+		return nil, time.Time{}, false, err
+	}
+	ticket.Status = "used"
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, time.Time{}, false, err
+	}
+	return &ticket, checkedInAt, false, nil
 }
 
 func emptyToNull(s string) interface{} {


### PR DESCRIPTION
Added organizer-only ticket check-in endpoint: POST /api/v1/events/:id/check-in.
Implemented check-in by either ticket_number or qr_code_value, with idempotent behavior (already_used on repeated scans).
Added backend support in models, handler interface, repository logic, route wiring, and handler unit test coverage.